### PR TITLE
DBT-321 Adding support for deserializing the date when it does not ha…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <packaging>jar</packaging>
 
     <description>
-      Provides support for serializing and deserializing Joda objects as ISO strings using Jackson.
+        Provides support for serializing and deserializing Joda objects as ISO strings using Jackson.
     </description>
 
     <scm>
@@ -44,17 +44,31 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
-            <version>2.2.2</version>
+            <version>2.10.4</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.2.2</version>
+            <version>2.10.4</version>
         </dependency>
         <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
-            <version>2.2</version>
+            <version>2.10.4</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/com/allogy/json/jackson/joda/ISODateTimeDeserializer.java
+++ b/src/main/java/com/allogy/json/jackson/joda/ISODateTimeDeserializer.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import org.joda.time.DateTime;
+import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.ISODateTimeFormat;
 
@@ -34,7 +35,8 @@ import java.io.IOException;
  */
 public class ISODateTimeDeserializer extends JsonDeserializer<DateTime>
 {
-    private final DateTimeFormatter dateTimeFormatter;
+    private DateTimeFormatter dateTimeFormatter;
+    private static final String WITHOUTMILLISFORMAT  = "yyyy-MM-dd'T'HH:mm:ssZ";
 
     public ISODateTimeDeserializer()
     {
@@ -44,14 +46,20 @@ public class ISODateTimeDeserializer extends JsonDeserializer<DateTime>
     @Override
     public DateTime deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException, JsonProcessingException
     {
+
         String text = jsonParser.getText();
         try
         {
-            return dateTimeFormatter.parseDateTime(text);
+            return  dateTimeFormatter.parseDateTime(text);
         }
         catch (Throwable throwable)
         {
-            throw new InvalidFormatException(throwable.getMessage(), text, String.class);
+           try{
+               dateTimeFormatter = DateTimeFormat.forPattern(WITHOUTMILLISFORMAT).withOffsetParsed();
+               return dateTimeFormatter.parseDateTime(text);
+           }catch(Throwable throwable2){
+               throw new InvalidFormatException(throwable2.getMessage(), text, String.class);
+           }
         }
     }
 }

--- a/src/main/java/test/com/allogy/json/jackson/joda/ISODateTimeDeserializerTest.java
+++ b/src/main/java/test/com/allogy/json/jackson/joda/ISODateTimeDeserializerTest.java
@@ -1,0 +1,71 @@
+package test.com.allogy.json.jackson.joda;
+
+import com.allogy.json.jackson.joda.ISODateTimeDeserializer;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import org.joda.time.DateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Payal Pandey
+ * @since Jun 18, 2020
+ */
+@RunWith(Parameterized.class)
+public class ISODateTimeDeserializerTest
+{
+
+    private JsonParser jsonParser;
+    private DeserializationContext deserializationContext;
+
+    @Parameterized.Parameter()
+    public String datePattern;
+
+    @Parameterized.Parameter(1)
+    public String inputDate;
+
+    @Parameterized.Parameter(2)
+    public String expected;
+
+    @Before
+    public void setUp()
+    {
+        jsonParser = mock(JsonParser.class);
+        deserializationContext = mock(DeserializationContext.class);
+    }
+
+    @Parameterized.Parameters(name = "{index}: Test with datePattern ={0}, inputDate ={1}, expected ={2}")
+    public static Collection<Object[]> data()
+    {
+        Object[][] data = new Object[][]{
+                {"yyyy-MM-dd'T'HH:mm:ss.SSSZ", "2001-07-04T12:08:56.235-07:00", "2001-07-04T12:08:56.235-07:00"},
+                {"yyyy-MM-dd'T'HH:mm:ssZ", "2001-07-04T12:08:56-07:00", "2001-07-04T12:08:56.000-07:00"}};
+        return Arrays.asList(data);
+    }
+
+    public ISODateTimeDeserializer createObjectUnderTest()
+    {
+        return new ISODateTimeDeserializer();
+    }
+
+    @Test
+    public void test_deserialize() throws IOException
+    {
+
+        when(jsonParser.getText()).thenReturn(inputDate);
+
+        DateTime result = createObjectUnderTest().deserialize(jsonParser, deserializationContext);
+        assertThat(result.toString(), equalTo(expected));
+    }
+}


### PR DESCRIPTION
…ve millisecond field. 
Updated jackson-core, jackson-databind and joda-time version to 2.10.4 from 2.2.2 .
Added Junit 4 test to verify that deserializer can support both date strings i.e. with or without milliseconds.